### PR TITLE
Create for developers

### DIFF
--- a/for developers
+++ b/for developers
@@ -1,0 +1,13 @@
+The Dev-Domains are open domains: anyone can register Dev-Domains. The Dev-Domain is meant for developers, but of course it also stands for any kind of "developments".
+
+The ICANN process of introducing new Top Level Domains continues. The registry of the Dev-Domains has set the 19th of January 2019 as the start of the Sunrise Period. Interested parties for the Sunrise Period must register with the Trademark Clearinghouse .
+
+Developments have now their own more secure home on the web: the Dev-Domain, the most relevant TLD for website and software developers.
+Key points about Dev-Domain:
+The Dev-Domain is an open TLD with a focus on improved security. The entire .Dev TLD has been added to the HSTS preload list, which means registrants will have to provision and set up SSL certificates in order for their content to be loaded in modern browsers
+
+The Dev-Domain is a secure namespace, meaning that HTTPS is required for all .Dev websites. You can buy your Dev-Domain now, but in order for it to work properly in browsers you must first configure HTTPS serving. You can acquire webspace with pre-configured encryption at Secura GmbH without any additional costs or SSL Certificates.
+
+Hans-Peter Oswald
+http://www.domainregistry.de/dev-domain.html
+http://www.domainregistry.de/software-domain.html


### PR DESCRIPTION
 The Dev-Domains are open domains: anyone can register Dev-Domains. The Dev-Domain is meant for developers, but of course it also stands for any kind of "developments".

The ICANN process of introducing new Top Level Domains continues. The registry of the Dev-Domains has set the 19th of January 2019 as the start of the Sunrise Period. Interested parties for the Sunrise Period must register with the Trademark Clearinghouse .

Developments have now their own more secure home on the web: the Dev-Domain, the most relevant TLD for website and software developers.

Google writes about Dev-Domains:

".dev is the perfect place for all developers to come together."

Key points about Dev-Domain:
The Dev-Domain is an open TLD with a focus on improved security. The entire .Dev TLD has been added to the HSTS preload list, which means registrants will have to provision and set up SSL certificates in order for their content to be loaded in modern browsers

The Dev-Domain is a secure namespace, meaning that HTTPS is required for all .Dev websites. You can buy your Dev-Domain now, but in order for it to work properly in browsers you must first configure HTTPS serving. You can acquire webspace with pre-configured encryption at Secura GmbH without any additional costs or SSL Certificates.

The standard Dev-Domain costs 49 US-Dollars per domain and year at the Sunrise Period and at the General Availability. In addition to the standard Dev-Dmains, Premium Dev-Domains are also offered. The price for the Premium Dev Domains is not only due in the first year, but annually.

Hans-Peter Oswald


http://www.domainregistry.de/dev-domain.html (English)

http://www.domainregistry.de/dev-domains.html (deutsch)

http://www.domainregistry.de/software-domain.html (English)
http://www.domainregistry.de/software-domains.html (German)